### PR TITLE
Fix/9 assertion error

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 88
+ignore = E402, W503
+builtins = _

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: CI
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    name: Lint with flake8
+  ci:
+    name: Lint and Test
     runs-on: ubuntu-latest
 
     steps:
@@ -20,10 +20,12 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
+          pip install -e ".[dev]"
       - name: Lint
         run: |
           # Stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics --builtins="_"
           # Exit if any flake8 issue is found (errors or warnings)
           flake8 . --count --max-complexity=10 --max-line-length=88 --statistics
+      - name: Test
+        run: pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,6 @@ classifiers = [
 Homepage = "https://github.com/sepehr-rs/sudoku-engine"
 Issues = "https://github.com/sepehr-rs/sudoku-engine/issues"
 GitHub = "https://github.com/sepehr-rs/sudoku-engine/py-sudoku"
+
+[project.optional-dependencies]
+dev = ["pytest", "flake8"]

--- a/sudoku/__init__.py
+++ b/sudoku/__init__.py
@@ -1,3 +1,4 @@
+from .base_sudoku import BaseSudoku
 from .variations import ClassicSudoku, DiagonalSudoku
 
 # from .exceptions import *

--- a/sudoku/base_sudoku.py
+++ b/sudoku/base_sudoku.py
@@ -1,13 +1,24 @@
 # base_sudoku.py
 
 from abc import ABC, abstractmethod
-from typing import List, Set, Tuple, Optional, Callable, Type
+from typing import (
+    List,
+    Set,
+    Tuple,
+    Optional,
+    Callable,
+    Type,
+    Iterable,
+    Dict,
+    Union,
+)
 import random
 import math
 
 Cell = Optional[int]
 Board = List[List[Cell]]
 Pos = Tuple[int, int]
+DifficultyInput = Union[int, float, str]
 
 
 class BaseSudoku(ABC):
@@ -73,7 +84,7 @@ class BaseSudoku(ABC):
     def board_copy(self) -> Board:
         return [row[:] for row in self.board]
 
-    def _check_unit(self, positions: List[Pos]) -> bool:
+    def _check_unit(self, positions: Iterable[Pos]) -> bool:
         """Helper: ensure no duplicate values in a given unit."""
         seen = set()
         for r, c in positions:
@@ -108,11 +119,11 @@ class Solver:
         self.board = puzzle.board_copy()
 
         # Precompute neighbors from regions
-        self.neighbors: dict[Pos, set[Pos]] = self._build_neighbors()
+        self.neighbors: Dict[Pos, Set[Pos]] = self._build_neighbors()
 
         # Candidate sets
         all_vals = set(range(1, self.N + 1))
-        self.cands: dict[Pos, set[int]] = {
+        self.cands: Dict[Pos, Set[int]] = {
             (r, c): all_vals - self._used_in_neighbors(r, c)
             for r in range(self.N)
             for c in range(self.N)
@@ -123,12 +134,12 @@ class Solver:
         self.solutions_found = 0
         self.first_solution: Optional[Board] = None
 
-    def _build_neighbors(self) -> dict[Pos, set[Pos]]:
+    def _build_neighbors(self) -> Dict[Pos, Set[Pos]]:
         """
         Precompute all neighbors of each cell from regions.
         Two cells are neighbors if they appear in the same region.
         """
-        neighbors: dict[Pos, set[Pos]] = {
+        neighbors: Dict[Pos, Set[Pos]] = {
             (r, c): set() for r in range(self.N) for c in range(self.N)
         }
         for region in self.puzzle.regions():
@@ -138,7 +149,7 @@ class Solver:
                         neighbors[(r1, c1)].add((r2, c2))
         return neighbors
 
-    def _used_in_neighbors(self, r: int, c: int) -> set[int]:
+    def _used_in_neighbors(self, r: int, c: int) -> Set[int]:
         """Values already present among a cell’s neighbors."""
         vals = set()
         for rr, cc in self.neighbors[(r, c)]:
@@ -156,7 +167,7 @@ class Solver:
     def place(self, r: int, c: int, v: int) -> List[Tuple[Pos, int]]:
         """Place value and update candidate sets."""
         self.board[r][c] = v
-        removed: list[tuple[Pos, int]] = []
+        removed: List[Tuple[Pos, int]] = []
         for nb in self.neighbors[(r, c)]:
             if nb in self.cands and v in self.cands[nb]:
                 self.cands[nb].remove(v)
@@ -219,7 +230,7 @@ class PuzzleGenerator:
     def make_puzzle(
         sudoku_cls: Type[BaseSudoku],
         size: int,
-        difficulty: float,
+        difficulty: DifficultyInput,
         ensure_unique: bool = True,
         seed: Optional[int] = None,
         seed_values: int = 0,
@@ -305,8 +316,9 @@ class PuzzleGenerator:
                 [(r, j) for j in range(size)]
                 + [(i, c) for i in range(size)]
             ):
-                if full.board[rr][cc] in candidates:
-                    candidates.remove(full.board[rr][cc])
+                cell = full.board[rr][cc]
+                if cell is not None and cell in candidates:
+                    candidates.remove(cell)
             if candidates:
                 full.board[r][c] = random.choice(list(candidates))
 

--- a/sudoku/base_sudoku.py
+++ b/sudoku/base_sudoku.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 from typing import List, Set, Tuple, Optional, Callable, Type
 import random
+import math
 
 Cell = Optional[int]
 Board = List[List[Cell]]
@@ -227,9 +228,48 @@ class PuzzleGenerator:
         Create a puzzle of given size and difficulty.
 
         difficulty: 0 < difficulty < 1 (fraction of cells to remove)
+
+        Validation policy:
+        - Accepted: int, float, numeric strings (e.g. "0.5")
+        - Rejected: bool, non-numeric strings, None
+        - Non-finite floats (NaN, inf, -inf) are rejected
+        - Range: 0 < difficulty < 1 (exclusive)
+
+        Raises:
+            TypeError: if input is not numeric or not coercible to float
+            ValueError: if numeric but invalid (out of range or non-finite)
+
         ensure_unique: enforce uniqueness of solution
         """
-        assert 0 < difficulty < 1, "Difficulty must be between 0 and 1"
+        # Check if bool (since bool is subclass of int)
+        if isinstance(difficulty, bool):
+            raise TypeError(
+                f"Difficulty cannot be bool. Received {difficulty!r} "
+                f"(type: {type(difficulty).__name__})"
+            )
+
+        # Try to coerce to float
+        try:
+            difficulty = float(difficulty)
+        except (TypeError, ValueError) as e:
+            raise TypeError(
+                f"Difficulty must be numeric. Received {difficulty!r} "
+                f"(type: {type(difficulty).__name__})"
+            ) from e
+
+        # Check if finite (not NaN, inf, or -inf)
+        if not math.isfinite(difficulty):
+            raise ValueError(
+                f"Difficulty must be finite. Received {difficulty!r} "
+                f"(type: {type(difficulty).__name__})"
+            )
+
+        # Check range (exclusive)
+        if not (0 < difficulty < 1):
+            raise ValueError(
+                f"Difficulty must be 0 < difficulty < 1. "
+                f"Received {difficulty!r} (type: {type(difficulty).__name__})"
+            )
 
         full = sudoku_cls(size=size)
 

--- a/sudoku/variations/classic_sudoku.py
+++ b/sudoku/variations/classic_sudoku.py
@@ -1,6 +1,6 @@
 # classic_sudoku.py
 
-from typing import List, Set
+from typing import List, Set, Optional
 from ..base_sudoku import BaseSudoku, Pos, Board
 import math
 
@@ -14,9 +14,9 @@ class ClassicSudoku(BaseSudoku):
     def __init__(
         self,
         size: int = 9,
-        board: Board = None,
-        box_height: int | None = None,
-        box_width: int | None = None,
+        board: Optional[Board] = None,
+        box_height: Optional[int] = None,
+        box_width: Optional[int] = None,
     ):
         super().__init__(size=size, board=board)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Tests directory for sudoku-engine

--- a/tests/test_difficulty_validation.py
+++ b/tests/test_difficulty_validation.py
@@ -1,5 +1,7 @@
 """Test suite for difficulty validation in PuzzleGenerator.make_puzzle"""
 
+from typing import Any, cast
+
 import pytest
 
 from sudoku.base_sudoku import PuzzleGenerator
@@ -51,7 +53,7 @@ class TestDifficultyInvalidType:
             PuzzleGenerator.make_puzzle(
                 sudoku_cls=ClassicSudoku,
                 size=4,
-                difficulty=None,
+                difficulty=cast(Any, None),
                 ensure_unique=False,
                 seed=1,
             )

--- a/tests/test_difficulty_validation.py
+++ b/tests/test_difficulty_validation.py
@@ -1,0 +1,248 @@
+"""Test suite for difficulty validation in PuzzleGenerator.make_puzzle"""
+
+import pytest
+
+from sudoku.base_sudoku import PuzzleGenerator
+from sudoku import ClassicSudoku
+
+
+class TestDifficultyInvalidType:
+    """Tests for TypeError cases (invalid types that cannot be coerced to float)"""
+
+    def test_non_numeric_string_raises_type_error(self):
+        """Non-numeric string like 'easy' should raise TypeError"""
+        with pytest.raises(TypeError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty="easy",
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_boolean_true_raises_type_error(self):
+        """Boolean True should raise TypeError"""
+        with pytest.raises(TypeError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=True,
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_boolean_false_raises_type_error(self):
+        """Boolean False should raise TypeError"""
+        with pytest.raises(TypeError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=False,
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_none_raises_type_error(self):
+        """None should raise TypeError"""
+        with pytest.raises(TypeError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=None,
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+
+class TestDifficultyInvalidValue:
+    """Tests for ValueError cases (valid types but invalid values)"""
+
+    def test_nan_raises_value_error(self):
+        """NaN should raise ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=float("nan"),
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_pos_inf_raises_value_error(self):
+        """Positive infinity should raise ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=float("inf"),
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_neg_inf_raises_value_error(self):
+        """Negative infinity should raise ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=float("-inf"),
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_zero_raises_value_error(self):
+        """Zero should raise ValueError (range is exclusive, 0 is invalid)"""
+        with pytest.raises(ValueError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=0,
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_one_raises_value_error(self):
+        """One should raise ValueError (range is exclusive, 1 is invalid)"""
+        with pytest.raises(ValueError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=1,
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_zero_float_raises_value_error(self):
+        """Zero float should raise ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=0.0,
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_one_float_raises_value_error(self):
+        """One float should raise ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=1.0,
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_negative_raises_value_error(self):
+        """Negative value should raise ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=-0.5,
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_greater_than_one_raises_value_error(self):
+        """Value greater than 1 should raise ValueError"""
+        with pytest.raises(ValueError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=1.5,
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+
+class TestDifficultyValidInput:
+    """Tests for valid inputs that should pass validation"""
+
+    def test_float_0_5_smoke_test(self):
+        """Float 0.5 with size=4 should create a valid puzzle (smoke test)"""
+        puzzle = PuzzleGenerator.make_puzzle(
+            sudoku_cls=ClassicSudoku,
+            size=4,
+            difficulty=0.5,
+            ensure_unique=False,
+            seed=1,
+        )
+        assert puzzle is not None
+
+    def test_numeric_string_0_5(self):
+        """Numeric string '0.5' should be coerced and accepted"""
+        puzzle = PuzzleGenerator.make_puzzle(
+            sudoku_cls=ClassicSudoku,
+            size=4,
+            difficulty="0.5",
+            ensure_unique=False,
+            seed=1,
+        )
+        assert puzzle is not None
+
+    def test_integer_0_5_converted_to_float(self):
+        """Integer 0.5 doesn't exist, but test that valid float conversions work"""
+        # Integer 0 is invalid (out of range)
+        # Integer 1 is invalid (out of range)
+        # Integer 0 and 1 should be tested in invalid value tests
+
+    def test_edge_valid_0_1(self):
+        """Float 0.1 should be valid (0 < 0.1 < 1)"""
+        puzzle = PuzzleGenerator.make_puzzle(
+            sudoku_cls=ClassicSudoku,
+            size=4,
+            difficulty=0.1,
+            ensure_unique=False,
+            seed=1,
+        )
+        assert puzzle is not None
+
+    def test_edge_valid_0_9(self):
+        """Float 0.9 should be valid (0 < 0.9 < 1)"""
+        puzzle = PuzzleGenerator.make_puzzle(
+            sudoku_cls=ClassicSudoku,
+            size=4,
+            difficulty=0.9,
+            ensure_unique=False,
+            seed=1,
+        )
+        assert puzzle is not None
+
+    def test_integer_0_2(self):
+        """Integer 2 should be invalid (out of range)"""
+        with pytest.raises(ValueError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=2,
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()
+
+    def test_integer_0_3(self):
+        """Integer 3 should be invalid (out of range)"""
+        with pytest.raises(ValueError) as exc_info:
+            PuzzleGenerator.make_puzzle(
+                sudoku_cls=ClassicSudoku,
+                size=4,
+                difficulty=3,
+                ensure_unique=False,
+                seed=1,
+            )
+        assert "difficulty" in str(exc_info.value).lower()


### PR DESCRIPTION
**Summary**
Fixes issue #9 by replacing assert 0 < difficulty < 1 in PuzzleGenerator.make_puzzle with explicit, user-facing validation that handles non-numeric inputs deterministically (no internal TypeError from comparisons/arithmetic).

**What Changed**
- sudoku/base_sudoku.py: validate/coerce difficulty early
  - Accepts int/float and numeric strings (e.g. "0.5")
  - Rejects bool explicitly, non-coercible values, and non-finite floats (NaN, inf)
  - Enforces 0 < difficulty < 1 (exclusive) with clear TypeError/ValueError messages
- Added pytest coverage for invalid/valid difficulty inputs:
  - tests/test_difficulty_validation.py
- Packaging/dev tooling:
  - pyproject.toml: add dev extras for pytest + flake8
  - .flake8: enforce max-line-length = 88 (existing repo convention)
- CI:
  - .github/workflows/ci.yml: run flake8 + pytest -q, install via pip install -e ".[dev]"
- Pyright cleanup:
  - Fix typing issues and Python 3.8-compat annotations (avoid dict[...] / int | None syntax)
  - Export BaseSudoku properly in sudoku/__init__.py to match __all__

**Verification**
- pytest -q
- flake8 . --count --max-complexity=10 --max-line-length=88 --statistics
- pyright

**Issue**
Closes/fixes: #9 